### PR TITLE
Fix non-concurrent index detection

### DIFF
--- a/lib/ast_parser.ex
+++ b/lib/ast_parser.ex
@@ -2,7 +2,6 @@ defmodule ExcellentMigrations.AstParser do
   @moduledoc false
   @max_columns_for_index 3
 
-  @index_functions [:create, :create_if_not_exists, :drop, :drop_if_exists]
   @index_types [:index, :unique_index]
 
   def parse(ast) do
@@ -37,16 +36,14 @@ defmodule ExcellentMigrations.AstParser do
       detect_json_column_added(code_part)
   end
 
-  defp detect_index_not_concurrently({fun_name, location, [{operation, _, [_, _]}]})
-       when fun_name in @index_functions and operation in @index_types do
-    [{:index_not_concurrently, Keyword.get(location, :line)}]
-  end
+  defp detect_index_not_concurrently({operation, location, args})
+       when operation in @index_types do
+    options = List.last(args, [])
 
-  defp detect_index_not_concurrently({fun_name, location, [{operation, _, [_, _, options]}]})
-       when fun_name in @index_functions and operation in @index_types do
-    case Keyword.get(options, :concurrently) do
-      true -> []
-      _ -> [{:index_not_concurrently, Keyword.get(location, :line)}]
+    if is_list(options) and Keyword.get(options, :concurrently) do
+      []
+    else
+      [{:index_not_concurrently, Keyword.get(location, :line)}]
     end
   end
 

--- a/lib/ast_parser.ex
+++ b/lib/ast_parser.ex
@@ -37,7 +37,7 @@ defmodule ExcellentMigrations.AstParser do
   end
 
   defp detect_index_not_concurrently({operation, location, args})
-       when operation in @index_types do
+       when is_list(args) and operation in @index_types do
     options = List.last(args, [])
 
     if is_list(options) and Keyword.get(options, :concurrently) do

--- a/test/ast_parser_test.exs
+++ b/test/ast_parser_test.exs
@@ -128,14 +128,18 @@ defmodule ExcellentMigrations.AstParserTest do
     ast_multi = string_to_ast("create index(:recipes, [:cuisine])")
     ast_multi_with_opts = string_to_ast("create index(:recipes, [:cuisine], unique: true)")
     ast_conc_false = string_to_ast("create index(:recipes, [:cuisine], concurrently: false)")
+    ast_pipeline = string_to_ast("index(:recipes, [:cuisine]) |> create()")
     ast_conc_true = string_to_ast("create index(:recipes, [:cuisine], concurrently: true)")
+    ast_invalid = string_to_ast("fn {index, id} -> create(index, id) end")
 
     assert [index_not_concurrently: 1] == AstParser.parse(ast_single)
     assert [index_not_concurrently: 1] == AstParser.parse(ast_single_with_opts)
     assert [index_not_concurrently: 1] == AstParser.parse(ast_multi)
     assert [index_not_concurrently: 1] == AstParser.parse(ast_multi_with_opts)
     assert [index_not_concurrently: 1] == AstParser.parse(ast_conc_false)
+    assert [index_not_concurrently: 1] == AstParser.parse(ast_pipeline)
     assert [] == AstParser.parse(ast_conc_true)
+    assert [] == AstParser.parse(ast_invalid)
   end
 
   test "detects index added not concurrently using if not exists" do

--- a/test/example_migrations/20230922211058_create_index_unconventional_structure.exs
+++ b/test/example_migrations/20230922211058_create_index_unconventional_structure.exs
@@ -1,0 +1,8 @@
+defmodule ExcellentMigrations.CreateIndexUnconventionalStructure do
+  def change do
+    dumplings_index = index(:dumplings, [:dough])
+    create(dumplings_index)
+
+    :dumplings |> index([:dough]) |> create()
+  end
+end

--- a/test/runner_test.exs
+++ b/test/runner_test.exs
@@ -138,6 +138,26 @@ defmodule ExcellentMigrations.RunnerTest do
            } == Runner.check_migrations(migrations_paths: file_paths)
   end
 
+  test "finds non-concurrent indices in unconventional structures" do
+    file_path = "test/example_migrations/20230922211058_create_index_unconventional_structure.exs"
+
+    assert {
+             :dangerous,
+             [
+               %{
+                 line: 3,
+                 path: file_path,
+                 type: :index_not_concurrently
+               },
+               %{
+                 line: 6,
+                 path: file_path,
+                 type: :index_not_concurrently
+               }
+             ]
+           } == Runner.check_migrations(migrations_paths: [file_path])
+  end
+
   test "no dangerous operations" do
     file_paths = [
       "test/example_migrations/20191026103003_create_table.exs",


### PR DESCRIPTION
Fixes https://github.com/Artur-Sulej/excellent_migrations/issues/33

The previous code expected `index/3` to be wrapped by `create`, `drop`, etc letting you bypass the check by defining the index in a pipeline. The change here will match all calls of `index`/`unique_index` independently of the structure